### PR TITLE
Change 'Api docs' link to use gitpages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If for some reason your credentials become corrupted and stop working, there is 
 
 ## API endpoints
 
-For details about the API, including available endpoints where data can be requested, see the [Hakai API documentation](https://github.com/HakaiInstitute/hakai-api).
+For details about the API, including available endpoints where data can be requested, see the [Hakai API documentation](http://hakaiinstitute.github.io/hakai-api/).
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If for some reason your credentials become corrupted and stop working, there is 
 
 ## API endpoints
 
-For details about the API, including available endpoints where data can be requested, see the [Hakai API documentation](http://hakaiinstitute.github.io/hakai-api/).
+For details about the API, including available endpoints where data can be requested, see the [Hakai API documentation](https://hakaiinstitute.github.io/hakai-api/).
 
 ## Advanced usage
 


### PR DESCRIPTION
Currently the README link goes to a private repo (hakai-api), which shows up as 404 if you don't have permissions on that repo. Many users will have access to use the API but not have access to the hakai-api repo, so I'm switching it to the public docs site - hakaiinstitute.github.io/hakai-api