### PR TITLE
Fixed the unknown function `type_convert` error

### DIFF
--- a/hakaiApi/.Rbuildignore
+++ b/hakaiApi/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^LICENSE\.md$

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Create an authenticated HTTP request client for the Hakai API
 Version: 0.1.3
 Authors@R: person("Taylor", "Denouden", email = "taylor.denouden@hakai.org", role = c("aut", "cre"))
 Description: Initalizes a class that obtains API credentials and provides a method to use those credentials to make GET requests to the Hakai API server.
-Depends: R (>= 3.3.3)
+Depends: R (>= 3.3.0)
 Imports:
   httr (>= 1.2.1),
   urltools (>= 1.6.0),

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -8,7 +8,7 @@ Imports:
   httr (>= 1.2.1),
   urltools (>= 1.6.0),
   readr (>= 1.3.1)
-License: MIT
+License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -3,8 +3,8 @@ Title: Create an authenticated HTTP request client for the Hakai API
 Version: 0.1.3
 Authors@R: person("Taylor", "Denouden", email = "taylor.denouden@hakai.org", role = c("aut", "cre"))
 Description: Initalizes a class that obtains API credentials and provides a method to use those credentials to make GET requests to the Hakai API server.
+Depends: R (>= 3.3.3)
 Imports:
-  R (>= 3.3.3),
   httr (>= 1.2.1),
   urltools (>= 1.6.0),
   readr (>= 1.3.1)

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Create an authenticated HTTP request client for the Hakai API
 Version: 0.1.3
 Authors@R: person("Taylor", "Denouden", email = "taylor.denouden@hakai.org", role = c("aut", "cre"))
 Description: Initalizes a class that obtains API credentials and provides a method to use those credentials to make GET requests to the Hakai API server.
-Depends:
+Imports:
   R (>= 3.3.3),
   httr (>= 1.2.1),
   urltools (>= 1.6.0),

--- a/hakaiApi/LICENSE
+++ b/hakaiApi/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2021
+COPYRIGHT HOLDER: Hakai Institute

--- a/hakaiApi/LICENSE.md
+++ b/hakaiApi/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 Hakai Institute
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hakaiApi/R/Client.R
+++ b/hakaiApi/R/Client.R
@@ -35,7 +35,7 @@ Client <- R6Class("Client",
       r <- httr::GET(endpointUrl, httr::add_headers(Authorization = token))
       data <- private$json2tbl(httr::content(r))
       data <- tibble::as_tibble(data)
-      data <- type_convert(data)
+      data <- readr::type_convert(data)
       return(data)
     },
     remove_old_credentials = function() {


### PR DESCRIPTION
The problem was that the type_convert function did not include the explicit package that it came from ie. readr::type_convert.

This PR also changed the description file so only R is listed in Depends: and all other packages are listed in imports. The difference is that listing packages in Depends _attaches_ them before the hakaiApi package when library(hakaiApi) is called, whereas Imports: imports namespaces (which don't need to be attached since each R function that uses imported namespaces loads libraries only when they are used via the :: function).

I also removed the patch version requirement on R 3.3.3 so now it's 3.3.0 as it's unlikely the patch version affects compatability