### PR TITLE
Add R API client to CRAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This project exports a single R6 class for the R programming language that can b
 
 ## Installation
 
-Before using this library, install it into your environment using the following in your R script:
+Before using this library, install it into your environment using one of the following in your R script:
 
 ```r
+# From CRAN
+install.packages("hakaiApi")
+
+# OR, the latest version from GitHub
 install.packages("remotes")
 remotes::install_github("HakaiInstitute/hakai-api-client-r", subdir='hakaiApi')
 ```

--- a/build.R
+++ b/build.R
@@ -26,6 +26,8 @@ devtools::check_man()
 # Check best practices
 goodpractice::gp()
 
+usethis::use_tidy_description()
+
 # Run inteRgrate checks
 inteRgrate::check_pkg()
 inteRgrate::check_lintr()
@@ -33,6 +35,9 @@ inteRgrate::check_tidy_description()
 inteRgrate::check_r_filenames()
 inteRgrate::check_gitignore()
 inteRgrate::check_version()
+
+# Spell check
+devtools::spell_check()
 
 # NOTE: Currently fails due to https://github.com/r-hub/rhub/issues/462. Once this issue is solved, we can upload to CRAN
 # Check for CRAN specific requirements using rhub and save it in the results objects
@@ -42,9 +47,6 @@ results$cran_summary()
 
 # Check for win-development
 devtools::check_win_devel()
-
-# Spell check
-devtools::spell_check()
 
 # One last check before release
 devtools::check()

--- a/build.R
+++ b/build.R
@@ -37,8 +37,17 @@ inteRgrate::check_version()
 # NOTE: Currently fails due to https://github.com/r-hub/rhub/issues/462. Once this issue is solved, we can upload to CRAN
 # Check for CRAN specific requirements using rhub and save it in the results objects
 results <- rhub::check_for_cran()
-# Get the summary of your results and save to cran-comments.md
+# Get the summary of your results. Manually, save the output cran-comments.md and explain any Notes at the bottom.
 results$cran_summary()
+
+# Check for win-development
+devtools::check_win_devel()
+
+# Spell check
+devtools::spell_check()
+
+# One last check before release
+devtools::check()
 
 # Release the package to CRAN
 devtools::release_checks()

--- a/build.R
+++ b/build.R
@@ -36,9 +36,9 @@ inteRgrate::check_version()
 
 # NOTE: Currently fails due to https://github.com/r-hub/rhub/issues/462. Once this issue is solved, we can upload to CRAN
 # Check for CRAN specific requirements using rhub and save it in the results objects
-# results <- rhub::check_for_cran()
+results <- rhub::check_for_cran()
 # Get the summary of your results and save to cran-comments.md
-# results$cran_summary()
+results$cran_summary()
 
 # Release the package to CRAN
 devtools::release_checks()

--- a/hakaiApi/.Rbuildignore
+++ b/hakaiApi/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
+^cran-comments\.md$

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: hakaiApi
-Title: Authenticated HTTP Request Client for the Hakai API
+Title: Authenticated HTTP Request Client for the 'Hakai' API
 Version: 1.0.0
 Authors@R: 
     c(person(given = "Taylor",
@@ -12,19 +12,16 @@ Authors@R:
              email = "brett.johnson@hakai.org"),
       person(given = "Nate",
              family = "Rosenstock",
-             role = "aut",
-             email = "nate.rosenstock@hakai.org"),
-      person(given = "Brett",
-             family = "Johnson",
              role = "ctb",
-             email = "brett.johnson@hakai.org"),
+             email = "nate.rosenstock@hakai.org"),
       person(given = "Chris",
              family = "Davis",
              role = "ctb",
              email = "chris.davis@hakai.org"))
 Description: Initializes a class that obtains API credentials and provides
-    a method to use those credentials to make GET requests to the Hakai
-    API server.
+    a method to use those credentials to make GET requests to the 'Hakai'
+    API server. Usage instructions are documented at
+    <https://hakaiinstitute.github.io/hakai-api/>.
 License: MIT + file LICENSE
 URL: https://github.com/HakaiInstitute/hakai-api-client-r
 BugReports: https://github.com/HakaiInstitute/hakai-api-client-r/issues

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -43,3 +43,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 RoxygenNote: 7.1.1
+Language: en-CA

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hakaiApi
 Title: Authenticated HTTP Request Client for the Hakai API
-Version: 0.2.1
+Version: 1.0.0
 Authors@R: 
     c(person(given = "Taylor",
              family = "Denouden",

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -42,5 +42,4 @@ Suggests:
 VignetteBuilder:
     knitr
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -42,5 +42,5 @@ Suggests:
 VignetteBuilder:
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.1.1
 Language: en-CA
+RoxygenNote: 7.1.1

--- a/hakaiApi/LICENSE
+++ b/hakaiApi/LICENSE
@@ -1,21 +1,20 @@
-# MIT License
+Copyright (c) 2021, Hakai Institute
 
-Copyright (c) 2021 Hakai Institute
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/hakaiApi/LICENSE
+++ b/hakaiApi/LICENSE
@@ -1,20 +1,2 @@
-Copyright (c) 2021, Hakai Institute
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+YEAR: 2021
+COPYRIGHT HOLDER: Hakai Institute

--- a/hakaiApi/LICENSE.md
+++ b/hakaiApi/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 Hakai Institute
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hakaiApi/NEWS.md
+++ b/hakaiApi/NEWS.md
@@ -1,4 +1,4 @@
-# hakaiApi 0.2.0
+# hakaiApi 1.0.0
 
 * Added a `NEWS.md` file to track changes to the package.
 * Prevent this packages dependencies from clashing with local packages.

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -7,6 +7,24 @@
 #' @importFrom readr type_convert
 #' @importFrom tibble as_tibble
 #' @export
+#' @examples
+#' # Initialize a new client
+#' client <- Client$new()
+#' # Follow authorization prompts to log in
+#'
+#' # Retrieve some data. See <https://hakaiinstitute.github.io/hakai-api/> for options.
+#' url <- paste0(client$api_root, "/aco/views/projects?project_year=2020&fields=project_name")
+#' projects_2020 <- client$get(url)
+#'
+#' print(projects_2020)
+#' # # A tibble: 20 x 1
+#' #    project_name
+#' #    <chr>
+#' #  1 Fountain FN
+#' #  2 Haig Glacier
+#' #  3 Fraser River - Chimney Creek West William Canyon
+#' #  4 Cruickshank WS
+#' #  ...
 Client <- R6::R6Class("Client",  # nolint
   lock_objects = FALSE,
   public = list(

--- a/hakaiApi/cran-comments.md
+++ b/hakaiApi/cran-comments.md
@@ -8,34 +8,9 @@
   checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Taylor Denouden <taylor.denouden@hakai.org>'
   
-  New submission
-  License components with restrictions and base license permitting such:
-    MIT + file LICENSE
-  File 'LICENSE':
-    # MIT License
-  
-    
-    Copyright (c) 2021 Hakai Institute
-    
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-    
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-    
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
   
   Possibly mis-spelled words in DESCRIPTION:
+  New submission
     Hakai (2:50, 26:67)
 
 - Hakai is the name of a research organization. This package helps to access this their data via an HTTP request API.

--- a/hakaiApi/cran-comments.md
+++ b/hakaiApi/cran-comments.md
@@ -1,0 +1,41 @@
+## Test environments
+- R-hub windows-x86_64-devel (r-devel)
+- R-hub ubuntu-gcc-release (r-release)
+- R-hub fedora-clang-devel (r-devel)
+
+## R CMD check results
+> On windows-x86_64-devel (r-devel), ubuntu-gcc-release (r-release), fedora-clang-devel (r-devel)
+  checking CRAN incoming feasibility ... NOTE
+  Maintainer: 'Taylor Denouden <taylor.denouden@hakai.org>'
+  
+  New submission
+  License components with restrictions and base license permitting such:
+    MIT + file LICENSE
+  File 'LICENSE':
+    # MIT License
+  
+    
+    Copyright (c) 2021 Hakai Institute
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  
+  Possibly mis-spelled words in DESCRIPTION:
+    Hakai (2:50, 26:67)
+
+- Hakai is the name of a research organization. This package helps to access this their data via an HTTP request API.

--- a/hakaiApi/cran-comments.md
+++ b/hakaiApi/cran-comments.md
@@ -8,9 +8,6 @@
   checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Taylor Denouden <taylor.denouden@hakai.org>'
   
-  
-  Possibly mis-spelled words in DESCRIPTION:
   New submission
-    Hakai (2:50, 26:67)
 
-- Hakai is the name of a research organization. This package helps to access this their data via an HTTP request API.
+0 errors ✓ | 0 warnings ✓ | 1 note x

--- a/hakaiApi/man/Client.Rd
+++ b/hakaiApi/man/Client.Rd
@@ -7,6 +7,23 @@
 Class to use to make authenticated API requests for Hakai data
 }
 \examples{
+# Initialize a new client
+client <- Client$new()
+# Follow authorization prompts to log in
+
+# Retrieve some data. See <https://hakaiinstitute.github.io/hakai-api/> for options.
+url <- paste0(client$api_root, "/aco/views/projects?project_year=2020&fields=project_name")
+projects_2020 <- client$get(url)
+
+print(projects_2020)
+# # A tibble: 20 x 1
+#    project_name
+#    <chr>
+#  1 Fountain FN
+#  2 Haig Glacier
+#  3 Fraser River - Chimney Creek West William Canyon
+#  4 Cruickshank WS
+#  ...
 
 ## ------------------------------------------------
 ## Method `Client$new`


### PR DESCRIPTION
Package has been uploaded to CRAN and is awaiting approval and publication.

This should be merged after the package can be installed using `install.packages("hakaiApi")`