### PR TITLE
FEAT: handle api lists

### DIFF
--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -15,7 +15,7 @@ License: MIT + file LICENSE
 URL: https://github.com/HakaiInstitute/hakai-api-client-r
 BugReports: https://github.com/HakaiInstitute/hakai-api-client-r/issues
 Depends:
-    R (>= 3.3.0)
+    R (>= 4.2.0)
 Imports:
     dplyr,
     httr2,

--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -25,9 +25,11 @@ Imports:
 Suggests:
     knitr,
     markdown,
-    rmarkdown
+    rmarkdown,
+    testthat (>= 3.0.0)
 VignetteBuilder:
     knitr
 Encoding: UTF-8
 Language: en-CA
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/hakaiApi/NEWS.md
+++ b/hakaiApi/NEWS.md
@@ -1,8 +1,16 @@
 # hakaiApi 1.0.2.9000
 
+Bug fixes
+* `get` method now returns tibbles for list responses
+* bump minimum R version to 4.2 to handle using native pipe
+
+
 Enhancements
 
 * wrap examples in `try()`
+* now setting the user agent for the client
+* extract `base_request` and `json2tbl` into separate functions to add some unit tests
+
 
 # hakaiApi 1.0.2
 

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -78,9 +78,9 @@ Client <- R6::R6Class("Client",  # nolint
     get = function(endpoint_url) {
       token <- paste(private$credentials$token_type,
                      private$credentials$access_token)
-      r <- httr2::request(endpoint_url) |>
-        httr2::req_headers("Authorization" = token) |>
+      r <- base_request(endpoint_url, token) |> 
         httr2::req_perform()
+      data <- httr2::resp_body_json(r)
       data <- private$json2tbl(httr2::resp_body_json(r))
       data <- tibble::as_tibble(data)
       data <- readr::type_convert(data)
@@ -95,8 +95,7 @@ Client <- R6::R6Class("Client",  # nolint
     post = function(endpoint_url, rec_data) {
       token <- paste(private$credentials$token_type,
                      private$credentials$access_token)
-      resp <- httr2::request(endpoint_url) |>
-        httr2::req_headers("Authorization" = token) |>
+      resp <- base_request(endpoint_url, token) |>
         httr2::req_method("POST") |>
         httr2::req_body_json(rec_data) |>
         httr2::req_perform()
@@ -112,8 +111,7 @@ Client <- R6::R6Class("Client",  # nolint
     put = function(endpoint_url, rec_data) {
       token <- paste(private$credentials$token_type,
                      private$credentials$access_token)
-      resp <- httr2::request(endpoint_url) |>
-        httr2::req_headers("Authorization" = token) |>
+      resp <- base_request(endpoint_url, token) |>
         httr2::req_body_json(data = rec_data, auto_unbox = TRUE) |>
         httr2::req_method("PUT") |>
         httr2::req_perform()
@@ -129,8 +127,7 @@ Client <- R6::R6Class("Client",  # nolint
     patch = function(endpoint_url, rec_data) {
       token <- paste(private$credentials$token_type,
                      private$credentials$access_token)
-      resp <- httr2::request(endpoint_url) |>
-        httr2::req_headers("Authorization" = token) |>
+      resp <- base_request(endpoint_url, token) |>
         httr2::req_body_json(data = rec_data, auto_unbox = TRUE) |>
         httr2::req_method("PATCH") |>
         httr2::req_perform()

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -152,6 +152,10 @@ Client <- R6::R6Class("Client",  # nolint
     credentials_file = NULL,
     credentials = NULL,
     json2tbl = function(data) {
+      # Handle special case of single vectors
+      if (all(sapply(data, length) == 1)) {
+        return(unlist(data))
+      }
       data <- lapply(data, function(data) {
         data[sapply(data, is.null)] <- NA  # nolint
         unlist(data)

--- a/hakaiApi/R/utils.R
+++ b/hakaiApi/R/utils.R
@@ -1,0 +1,5 @@
+base_request <- function(endpoint_url, token) {
+  httr2::request(endpoint_url) |>
+    httr2::req_headers("Authorization" = token) |>
+    httr2::req_user_agent("hakai-api-client-r") 
+}

--- a/hakaiApi/R/utils.R
+++ b/hakaiApi/R/utils.R
@@ -3,3 +3,17 @@ base_request <- function(endpoint_url, token) {
     httr2::req_headers("Authorization" = token) |>
     httr2::req_user_agent("hakai-api-client-r") 
 }
+
+
+json2tbl_impl <- function(data) {
+  # Handle special case of single vectors
+  if (all(sapply(data, length) == 1)) {
+    return(tibble::tibble(value = unlist(data)))
+  }
+  data <- lapply(data, function(data) {
+    data[sapply(data, is.null)] <- NA  # nolint
+    unlist(data)
+  })
+  data <- bind_rows(data)
+  return(data)
+}

--- a/hakaiApi/man/Client.Rd
+++ b/hakaiApi/man/Client.Rd
@@ -121,13 +121,15 @@ A client instance
 \subsection{Method \code{get()}}{
 Send a GET request to the API
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Client$get(endpoint_url)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Client$get(endpoint_url, col_types = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{endpoint_url}}{The full API url to fetch data from}
+
+\item{\code{col_types}}{a readr type specification}
 }
 \if{html}{\out{</div>}}
 }

--- a/hakaiApi/tests/testthat.R
+++ b/hakaiApi/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(hakaiApi)
+
+test_check("hakaiApi")

--- a/hakaiApi/tests/testthat/test-utils.R
+++ b/hakaiApi/tests/testthat/test-utils.R
@@ -6,3 +6,75 @@ test_that("base_request returns ", {
   expect_equal(req$headers$Authorization, "detoo")
   expect_equal(req$options$useragent, "hakai-api-client-r")
 })
+
+
+test_that("json2tbl_impl handles list of simple character values correctly", {
+  # Test data - list of single character values
+  test_data <- list(
+    "Millennium Falcon",
+    "Death Star",
+    "Star Destroyer"
+  )
+  
+  result <- json2tbl_impl(test_data)
+  
+  # Should return a tibble with a single column
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 3)
+  expect_equal(ncol(result), 1)
+  expect_equal(colnames(result), "value")
+  expect_equal(result$value, c("Millennium Falcon", "Death Star", "Star Destroyer"))
+})
+
+test_that("json2tbl_impl handles objects with NULL values correctly", {
+  # Test data - objects with NULL values
+  test_data <- list(
+    list(name = "Obi-Wan Kenobi", planet = "Tatooine", ship = NULL),
+    list(name = "C-3PO", planet = NULL, ship = "Millennium Falcon"),
+    list(name = NULL, planet = "Endor", ship = "Imperial Shuttle")
+  )
+  
+  result <- json2tbl_impl(test_data)
+  
+  # Should return a tibble with NAs for NULL values
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 3)
+  expect_equal(ncol(result), 3)
+  expect_equal(is.na(result$ship[1]), TRUE)
+  expect_equal(is.na(result$planet[2]), TRUE)
+  expect_equal(is.na(result$name[3]), TRUE)
+})
+
+test_that("json2tbl_impl handles mixed length lists correctly", {
+  # Test data - mixed length objects
+  test_data <- list(
+    list(planet = "Tatooine", terrain = "Desert"),
+    list(planet = "Hoth", terrain = "Ice", native_species = "Wampa"), 
+    list(planet = "Dagobah")
+  )
+  
+  result <- json2tbl_impl(test_data)
+  
+  # Should return a tibble with all columns from all objects
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 3)
+  expect_equal(ncol(result), 3)
+  expect_equal(result$planet, c("Tatooine", "Hoth", "Dagobah"))
+  expect_equal(result$terrain[1:2], c("Desert", "Ice"))
+  expect_equal(is.na(result$terrain[3]), TRUE)
+  expect_equal(result$native_species[2], "Wampa")
+  expect_equal(is.na(result$native_species[1]), TRUE)
+  expect_equal(is.na(result$native_species[3]), TRUE)
+})
+
+test_that("json2tbl_impl handles empty lists correctly", {
+  # Test data - empty list
+  test_data <- list()
+  
+  result <- json2tbl_impl(test_data)
+  
+  # Should return an empty tibble
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 0)
+  expect_equal(ncol(result), 0)
+})

--- a/hakaiApi/tests/testthat/test-utils.R
+++ b/hakaiApi/tests/testthat/test-utils.R
@@ -1,0 +1,8 @@
+test_that("base_request returns ", {
+  req <- base_request("artoo", "detoo")
+
+  expect_s3_class(req, "httr2_request")
+  expect_equal(req$url, "artoo")
+  expect_equal(req$headers$Authorization, "detoo")
+  expect_equal(req$options$useragent, "hakai-api-client-r")
+})


### PR DESCRIPTION
This PR's main intent was to fix some behaviour where the client has some trouble handling lists from the API. See below for the old and new behaviour. 

However I took the opportunity to add some unit tests to any code I was touching which led to a few enhancements:
- added a user agent to the calls
- extracted out a few functions into their own implementation to make them simpler to test
- bumping the minimum R version because of the use of R's native pipe (the package would not have worked with any version of R before 4.2)
- added some units tests 

### Old behaviour:

``` r
library(hakaiApi)
client <- Client$new()

sa_list <- client$get("https://hecate.hakai.org/api/sn/tables/list")
#> Error in `bind_rows()`:
#> ! Argument 1 must be a data frame or a named atomic vector.

head(sa_list)
#> Error: object 'sa_list' not found
```

### New behaviour

``` r
library(hakaiApi)
client <- Client$new()

sa_list <- client$get("https://hecate.hakai.org/api/sn/tables/list")

head(sa_list)
#> # A tibble: 6 × 1
#>   value                                  
#>   <chr>                                  
#> 1 SA_Simmonds_kelp:5minuteSamples        
#> 2 SA_Spider_kelp:1daySamples             
#> 3 W50_SalmTrib16_T1:1daySamples          
#> 4 SA_Spider_kelp:1hourSamples            
#> 5 SA_Spider_kelp:5minuteSamples          
#> 6 SA_Little_wolf_pyropia_high:1daySamples
```
