### PR TITLE
CRAN fix. 

### DIFF
--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hakaiApi
 Title: Authenticated HTTP Request Client for the 'Hakai' API
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person("Sam", "Albers", , "sam.albers@hakai.org", role = c("aut", "cre")),
     person("Taylor", "Denouden", , "taylor.denouden@hakai.org", role = "aut"),
@@ -28,6 +28,7 @@ Suggests:
     knitr,
     markdown,
     rmarkdown,
+    withr,
     testthat (>= 3.0.0)
 VignetteBuilder:
     knitr

--- a/hakaiApi/NAMESPACE
+++ b/hakaiApi/NAMESPACE
@@ -2,11 +2,9 @@
 
 export(Client)
 importFrom(R6,R6Class)
-importFrom(dplyr,bind_rows)
 importFrom(httr2,req_body_json)
 importFrom(httr2,req_headers)
 importFrom(httr2,req_method)
 importFrom(httr2,req_perform)
 importFrom(httr2,request)
 importFrom(readr,type_convert)
-importFrom(tibble,as_tibble)

--- a/hakaiApi/NEWS.md
+++ b/hakaiApi/NEWS.md
@@ -1,3 +1,8 @@
+# hakaiApi 1.0.5
+
+* CRAN fix: Moved credential storage to proper user directories and added permission prompts to comply with CRAN policies.
+* Fixed typos in auth prompts and added test coverage for environment variable handling.
+
 # hakaiApi 1.0.4
 
 Enhancements

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -7,8 +7,6 @@
 #' @importFrom R6 R6Class
 #' @importFrom httr2 request req_headers req_method req_body_json req_perform
 #' @importFrom readr type_convert
-#' @importFrom tibble as_tibble
-#' @importFrom dplyr bind_rows
 #' @export
 #' @examples
 #' \dontrun{
@@ -55,11 +53,11 @@ Client <- R6::R6Class(
     #' @param login_page Optional API login page url to display to user.
     #' Defaults to "https://hecate.hakai.org/api-client-login"
     #' @param credentials_file Optional path to the credentials cache file.
-    #' Defaults to "~/.hakai-api-auth-r"
+    #' Defaults to a file in the user's data directory as determined by tools::R_user_dir()
     #' @details
     #' Credentials can be provided in two ways:
     #' 1. Via the HAKAI_API_TOKEN environment variable (contains query string: "token_type=Bearer&access_token=...")
-    #' 2. Via a credentials file (default: ~/.hakai-api-auth-r)
+    #' 2. Via a credentials file (default: in user data directory via tools::R_user_dir())
     #' The environment variable takes precedence if both are available.
     #' @return A client instance
     #' @examples
@@ -78,11 +76,18 @@ Client <- R6::R6Class(
     initialize = function(
       api_root = "https://hecate.hakai.org/api",
       login_page = "https://hecate.hakai.org/api-client-login",
-      credentials_file = "~/.hakai-api-auth-r"
+      credentials_file = NULL
     ) {
       self$api_root <- api_root
       private$login_page_url <- login_page
-      private$credentials_file <- path.expand(credentials_file)
+
+      # Set default credentials file location using R_user_dir
+      if (is.null(credentials_file)) {
+        user_dir <- tools::R_user_dir("hakaiApi", "data")
+        private$credentials_file <- file.path(user_dir, ".hakai-api-auth-r")
+      } else {
+        private$credentials_file <- path.expand(credentials_file)
+      }
 
       credentials <- private$try_to_load_credentials()
       if (is.list(credentials)) {
@@ -230,13 +235,32 @@ Client <- R6::R6Class(
       )
     },
     get_credentials_from_web = function() {
+      # Ask for permission to store credentials before getting them
+      if (interactive()) {
+        message(
+          "hakaiApi would like to store credentials in: ",
+          private$credentials_file
+        )
+        choice <- utils::menu(
+          c("Yes", "No"),
+          title = "Store credentials file?"
+        )
+        if (choice != 1) {
+          stop(
+            "Permission denied to store credentials file. ",
+            "Alternative: Set environment variable HAKAI_API_TOKEN with your credentials.",
+            call. = FALSE
+          )
+        }
+      }
+
       # Get the user to login and get the oAuth2 code from the redirect url
       writeLines("Please go here and authorize:")
       writeLines(private$login_page_url)
       writeLines("")
 
       querystring <- readline(
-        "Copy and past your credentials from the login page:\n"
+        "Copy and paste the full credential string from the login page:\n"
       )
       credentials <- private$querystring2df(querystring)
       return(credentials)
@@ -262,6 +286,7 @@ Client <- R6::R6Class(
 
       # If no environment variable, fall back to file-based credentials
       # Check the cached credentials file exists
+      message(private$credentials_file)
       if (!file.exists(private$credentials_file)) {
         return(FALSE)
       }
@@ -291,6 +316,12 @@ Client <- R6::R6Class(
       credentials
     },
     save_credentials = function(credentials) {
+      # Ensure the directory exists before saving
+      cred_dir <- dirname(private$credentials_file)
+      if (!dir.exists(cred_dir)) {
+        dir.create(cred_dir, recursive = TRUE)
+      }
+
       # Save the credentials to the self$credentials_file location
       credentials_file <- file(private$credentials_file, "w")
       serialize(credentials, credentials_file)

--- a/hakaiApi/R/utils.R
+++ b/hakaiApi/R/utils.R
@@ -12,14 +12,14 @@ resolve_url <- function(endpoint_url, api_root) {
   if (grepl("^https?://", endpoint_url)) {
     return(endpoint_url)
   }
-  
+
   # For relative URLs, prepend the api_root
   # Remove any leading slash from endpoint_url to avoid double slashes
   endpoint_url <- sub("^/+", "", endpoint_url)
-  
+
   # Remove any trailing slash from api_root to avoid double slashes
   api_root <- sub("/+$", "", api_root)
-  
+
   return(paste0(api_root, "/", endpoint_url))
 }
 
@@ -35,4 +35,9 @@ json2tbl_impl <- function(data) {
   })
   data <- dplyr::bind_rows(data)
   return(data)
+}
+
+
+are_credentials_expired <- function(credentials) {
+  as.numeric(Sys.time()) > credentials$expires_at
 }

--- a/hakaiApi/man/Client.Rd
+++ b/hakaiApi/man/Client.Rd
@@ -101,7 +101,7 @@ Log into Google to gain credential access to the API
 \if{html}{\out{<div class="r">}}\preformatted{Client$new(
   api_root = "https://hecate.hakai.org/api",
   login_page = "https://hecate.hakai.org/api-client-login",
-  credentials_file = "~/.hakai-api-auth-r"
+  credentials_file = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -115,14 +115,14 @@ Defaults to "https://hecate.hakai.org/api"}
 Defaults to "https://hecate.hakai.org/api-client-login"}
 
 \item{\code{credentials_file}}{Optional path to the credentials cache file.
-Defaults to "~/.hakai-api-auth-r"}
+Defaults to a file in the user's data directory as determined by tools::R_user_dir()}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
 Credentials can be provided in two ways:
 1. Via the HAKAI_API_TOKEN environment variable (contains query string: "token_type=Bearer&access_token=...")
-2. Via a credentials file (default: ~/.hakai-api-auth-r)
+2. Via a credentials file (default: in user data directory via tools::R_user_dir())
 The environment variable takes precedence if both are available.
 }
 

--- a/hakaiApi/tests/testthat/test-client.R
+++ b/hakaiApi/tests/testthat/test-client.R
@@ -3,7 +3,7 @@ test_that("absolute URLs are returned unchanged", {
   api_root <- "https://my-api.com/api"
   resolved <- hakaiApi:::resolve_url(absolute_url, api_root)
   expect_equal(resolved, absolute_url)
-  
+
   # Test http URLs too
   http_url <- "http://external-api.com/endpoint"
   resolved_http <- hakaiApi:::resolve_url(http_url, api_root)
@@ -12,11 +12,11 @@ test_that("absolute URLs are returned unchanged", {
 
 test_that("resolve_url handles relative URLs and slashes correctly", {
   api_root <- "https://my-api.com/api"
-  
+
   relative_url <- "/path/to/endpoint"
   resolved <- hakaiApi:::resolve_url(relative_url, api_root)
   expect_equal(resolved, "https://my-api.com/api/path/to/endpoint")
-  
+
   relative_url_no_slash <- "path/to/endpoint"
   resolved_no_slash <- hakaiApi:::resolve_url(relative_url_no_slash, api_root)
   expect_equal(resolved_no_slash, "https://my-api.com/api/path/to/endpoint")
@@ -29,18 +29,24 @@ test_that("resolve_url handles api_root with trailing slashes", {
   expect_equal(resolved, "https://my-api.com/api/path/to/endpoint")
 
   api_root_multiple_slashes <- "https://my-api.com/api///"
-  resolved_multiple <- hakaiApi:::resolve_url(relative_url, api_root_multiple_slashes)
+  resolved_multiple <- hakaiApi:::resolve_url(
+    relative_url,
+    api_root_multiple_slashes
+  )
   expect_equal(resolved_multiple, "https://my-api.com/api/path/to/endpoint")
 })
 
 test_that("resolve_url handles query parameters correctly", {
   api_root <- "https://my-api.com/api"
-  
+
   # Test relative URL with query parameters
   relative_url <- "/path/to/endpoint?param1=value1&param2=value2"
   resolved <- hakaiApi:::resolve_url(relative_url, api_root)
-  expect_equal(resolved, "https://my-api.com/api/path/to/endpoint?param1=value1&param2=value2")
-  
+  expect_equal(
+    resolved,
+    "https://my-api.com/api/path/to/endpoint?param1=value1&param2=value2"
+  )
+
   # Test absolute URL with query parameters (should remain unchanged)
   absolute_url <- "https://external-api.com/endpoint?param=value"
   resolved_abs <- hakaiApi:::resolve_url(absolute_url, api_root)
@@ -49,14 +55,61 @@ test_that("resolve_url handles query parameters correctly", {
 
 test_that("resolve_url handles edge cases", {
   api_root <- "https://my-api.com/api"
-  
+
   # Test empty endpoint
   empty_endpoint <- ""
   resolved_empty <- hakaiApi:::resolve_url(empty_endpoint, api_root)
   expect_equal(resolved_empty, "https://my-api.com/api/")
-  
+
   # Test just a slash
   slash_only <- "/"
   resolved_slash <- hakaiApi:::resolve_url(slash_only, api_root)
   expect_equal(resolved_slash, "https://my-api.com/api/")
+})
+
+
+test_that("Client uses environment variable when available", {
+  withr::with_envvar(
+    c(
+      HAKAI_API_TOKEN = "token_type=Bearer&access_token=dummy_token&expires_at=9999999999"
+    ),
+    {
+      temp_creds <- tempfile()
+
+      # Client should initialize successfully using env var
+      client <- Client$new(credentials_file = temp_creds)
+
+      expect_true(inherits(client, "Client"))
+      expect_false(file.exists(temp_creds))
+    }
+  )
+})
+
+test_that("Environment variable takes precedence over file", {
+  temp_creds <- tempfile()
+  dir.create(dirname(temp_creds), recursive = TRUE, showWarnings = FALSE)
+
+  # Create a dummy credentials file
+  dummy_file_creds <- list(
+    token_type = "Bearer",
+    access_token = "file_token",
+    expires_at = as.numeric(Sys.time()) + 3600
+  )
+  con <- file(temp_creds, "wb")
+  serialize(dummy_file_creds, con)
+  close(con)
+
+  withr::with_envvar(
+    c(
+      HAKAI_API_TOKEN = "token_type=Bearer&access_token=env_token&expires_at=9999999999"
+    ),
+    {
+      client <- Client$new(credentials_file = temp_creds)
+      expect_true(inherits(client, "Client"))
+      # File still exists but wasn't used (env var took precedence)
+      expect_true(file.exists(temp_creds))
+    }
+  )
+
+  unlink(temp_creds)
 })


### PR DESCRIPTION
We now write to the user directory in a CRAN friendly location `tools::R_user_dir("hakaiApi", "data")` and ask for permission. This is required to get back on CRAN. 

From CRAN:

```
~/.hakai-api-auth-r

apparently from

./man/Client.Rd:  credentials_file = "~/.hakai-api-auth-r"
./man/Client.Rd:Defaults to "~/.hakai-api-auth-r"}
./man/Client.Rd:2. Via a credentials file (default: ~/.hakai-api-auth-r)
./R/client.R:    #' Defaults to "~/.hakai-api-auth-r"
./R/client.R:    #' 2. Via a credentials file (default: ~/.hakai-api-auth-r)
./R/client.R:      credentials_file = "~/.hakai-api-auth-r"

in violation of the CRAN Policy's

  Packages should not write in the user’s home filespace (including
  clipboards), nor anywhere else on the file system apart from the R
  session’s temporary directory (or during installation in the location
  pointed to by TMPDIR: and such usage should be cleaned up). Installing
  into the system’s R installation (e.g., scripts to its bin directory)
  is not allowed.

  Limited exceptions may be allowed in interactive sessions if the
  package obtains confirmation from the user.

  For R version 4.0 or later (hence a version dependency is required or
  only conditional use is possible), packages may store user-specific
  data, configuration and cache files in their respective user
  directories obtained from tools::R_user_dir(), provided that by
  default sizes are kept as small as possible and the contents are
  actively managed (including removing outdated material).

We thus have to archive your package for policy violation
```