### PR TITLE
Add stations geojson

### DIFF
--- a/hakaiApi/DESCRIPTION
+++ b/hakaiApi/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hakaiApi
 Title: Authenticated HTTP Request Client for the 'Hakai' API
-Version: 1.0.5
+Version: 1.0.5.9000
 Authors@R: c(
     person("Sam", "Albers", , "sam.albers@hakai.org", role = c("aut", "cre")),
     person("Taylor", "Denouden", , "taylor.denouden@hakai.org", role = "aut"),
@@ -28,6 +28,7 @@ Suggests:
     knitr,
     markdown,
     rmarkdown,
+    sf,
     withr,
     testthat (>= 3.0.0)
 VignetteBuilder:

--- a/hakaiApi/NEWS.md
+++ b/hakaiApi/NEWS.md
@@ -1,3 +1,6 @@
+# hakaiApi 1.0.5.9000
+* ADd `get_stations()` method to retrieve list of stations as an sf object
+
 # hakaiApi 1.0.5
 
 * CRAN fix: Moved credential storage to proper user directories and added permission prompts to comply with CRAN policies.

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -120,6 +120,34 @@ Client <- R6::R6Class(
       data <- readr::type_convert(data, col_types = col_types)
       return(data)
     },
+    #' @description
+    #' Get recent sensor nodes and their locations as an sf object
+    #' @return An sf object of sensor nodes and their locations
+    #' @examples
+    #' try(client$get_stations())
+    get_stations = function() {
+      if (!requireNamespace("sf", quietly = TRUE)) {
+        stop(
+          "Package 'sf' is required. Install with: install.packages('sf')",
+          call. = FALSE
+        )
+      }
+      endpoint_url = "sn/recent_stations.geojson"
+      resolved_url <- private$resolve_url(endpoint_url)
+      token <- paste(
+        private$credentials$token_type,
+        private$credentials$access_token
+      )
+      r <- base_request(resolved_url, token) |>
+        httr2::req_perform()
+      data <- httr2::resp_body_string(r)
+      temp_file <- tempfile(fileext = ".geojson")
+      writeLines(foo, temp_file)
+
+      stations <- sf::read_sf(temp_file, quiet = TRUE)
+      on.exit(unlink(temp_file))
+      stations[, c("station_id", "sensor_node", "geometry")]
+    },
 
     #'@description
     #' Send a POST request to the API

--- a/hakaiApi/R/client.R
+++ b/hakaiApi/R/client.R
@@ -142,7 +142,7 @@ Client <- R6::R6Class(
         httr2::req_perform()
       data <- httr2::resp_body_string(r)
       temp_file <- tempfile(fileext = ".geojson")
-      writeLines(foo, temp_file)
+      writeLines(data, temp_file)
 
       stations <- sf::read_sf(temp_file, quiet = TRUE)
       on.exit(unlink(temp_file))


### PR DESCRIPTION
The addition of a stations endpoint enables functions that provide some basic spatial data like this. This PR adds that api to the R client which is really handy for making quick maps.

``` r
library(hakaiApi)
library(ggplot2)
library(bcmaps)
#> Loading required package: sf
#> Linking to GEOS 3.13.0, GDAL 3.8.5, PROJ 9.5.1; sf_use_s2() is TRUE
#> Support for Spatial objects (`sp`) was removed in {bcmaps} v2.0.0. Please use `sf` objects with {bcmaps}.
library(sf)

hakai_client <- hakaiApi::Client$new("https://hecate.hakai.org/api")
#> /Users/sam.albers/Library/Application Support/org.R-project.R/R/hakaiApi/.hakai-api-auth-r

stations <- hakai_client$get_stations()
bc <- bcmaps::bc_bound_hres()
#> bc_bound_hres was updated on NULL

points_bbox <- st_bbox(stations) |> 
  st_as_sfc() |> 
  st_transform(st_crs(bc))
clipped_polygon <- st_intersection(bc, points_bbox)
#> Warning: attribute variables are assumed to be spatially constant throughout
#> all geometries

ggplot() +
  geom_sf(data = clipped_polygon) +
  geom_sf(data = stations, aes(color = station_id), size = 3) +
  theme_minimal() +
  theme(legend.position = "bottom")
```

![](https://i.imgur.com/f3GowXS.png)<!-- -->

``` r

# Or an interactive map
# mapview::mapview(stations)
```

<sup>Created on 2025-09-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>